### PR TITLE
Added `updateWhenRebuild` to rebuild for some reason.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![pub package](https://img.shields.io/pub/v/flutter_sortable_wrap.svg)](https://pub.dev/packages/flutter_sortable_wrap)
 
+---
+Update for forked version
+- Updated to null safety version sdk
+- Added `updateWhenRebuild` property to update the list when rebuild the widget
+---
+
 ##### Build & Run `example/lib/main.dart` on iOS/Android/Chrome/MacOS for more demonstrations
 `cd example/; flutter clean; flutter run -d macOS`
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,7 +7,7 @@ void main() {
 }
 
 class App extends StatefulWidget {
-  const App({Key key}) : super(key: key);
+  const App({Key? key}) : super(key: key);
 
   @override
   AppState createState() => AppState();

--- a/example/lib/page/page_next.dart
+++ b/example/lib/page/page_next.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_sortable_wrap/flutter_sortable_wrap.dart';
 
 class PageNext extends StatefulWidget {
-  const PageNext({Key key}) : super(key: key);
+  const PageNext({Key? key}) : super(key: key);
 
   @override
   PageNextState createState() => PageNextState();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=3.1.2 <4.0.0"
 
 dependencies:
   flutter:

--- a/lib/sortable_wrap.dart
+++ b/lib/sortable_wrap.dart
@@ -71,7 +71,7 @@ class SortableWrapState extends State<SortableWrap> {
   @override
   void didUpdateWidget(covariant SortableWrap oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.updateWhenRebuild || widget.children.length != oldWidget.children.length) {
+    if ((!isDragging && widget.updateWhenRebuild) || widget.children.length != oldWidget.children.length) {
       /// TODO ... enhance when dragging ...
       initCachedWithChildren();
     }

--- a/lib/sortable_wrap.dart
+++ b/lib/sortable_wrap.dart
@@ -12,6 +12,7 @@ class SortableWrap extends StatefulWidget {
     this.spacing = 0.0,
     this.runSpacing = 0.0,
     this.options,
+    this.updateWhenRebuild = false,
   }) : super(key: key);
 
   final List<Widget> children;
@@ -28,6 +29,7 @@ class SortableWrap extends StatefulWidget {
 
   /// Widget settings
   final SortableWrapOptions? options;
+  final bool updateWhenRebuild;
 
   @override
   State<SortableWrap> createState() => SortableWrapState();
@@ -69,7 +71,7 @@ class SortableWrapState extends State<SortableWrap> {
   @override
   void didUpdateWidget(covariant SortableWrap oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.children.length != oldWidget.children.length) {
+    if (widget.updateWhenRebuild || widget.children.length != oldWidget.children.length) {
       /// TODO ... enhance when dragging ...
       initCachedWithChildren();
     }

--- a/lib/sortable_wrap.dart
+++ b/lib/sortable_wrap.dart
@@ -285,6 +285,9 @@ class SortableWrapState extends State<SortableWrap> {
     SortableElement element = beHitItemState.widget.element;
 
     int toIndex = animationElements.indexOf(element);
+    if (widget.freezes?.contains(toIndex) == true) {
+      return;
+    }
     int draggingIndex = animationElements.indexOf(dragging);
     bool isDraggingInSameRow =
         toIndex ~/ elementCountPerRow == draggingIndex ~/ elementCountPerRow;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,7 @@ version: 1.0.5
 homepage: https://github.com/isaacselement/flutter_sortable_wrap
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.4"
+  sdk: ">=3.1.2 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
In my use case, I need to create a single-selection effect, so that each time an item is clicked, the appearance of the other items also needs to be updated simultaneously (if necessary). After a quick look at the source code, I realized that the refresh was not happening in the `didUpdateWidget` function; instead, it was using the previously cached widget. Therefore, I added the `updateWhenRebuild` property for this purpose. However, this is a **dreadful** PR as it modifies the SDK version. Is there any other way to meet my requirements?